### PR TITLE
fix: avoid of usage model shard in Octopus.using

### DIFF
--- a/ar-octopus.gemspec
+++ b/ar-octopus.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord', '>= 3.1.0', '< 4.0'
   s.add_dependency 'activesupport', '>= 3.1.0', '< 4.0'
   s.add_development_dependency 'rake', '>= 0.8.7'
-  s.add_development_dependency 'rspec', '>= 2.0.0'
+  s.add_development_dependency 'rspec', '~> 2.99.0'
   s.add_development_dependency 'mysql2', '> 0.3'
   s.add_development_dependency 'pg', '>= 0.11.0'
   s.add_development_dependency 'sqlite3', '>= 1.3.4'

--- a/lib/octopus/model.rb
+++ b/lib/octopus/model.rb
@@ -48,7 +48,11 @@ module Octopus::Model
 
     def hijack_connection()
       def self.should_use_normal_connection?
-        !Octopus.enabled? || self.custom_octopus_connection
+        if !Octopus.enabled?
+          true
+        elsif custom_octopus_connection
+          !connection_proxy.block
+        end
       end
 
       def self.connection_proxy
@@ -90,7 +94,7 @@ module Octopus::Model
     end
 
     def should_set_current_shard?
-      self.respond_to?(:current_shard) && !self.current_shard.nil?
+      !self.class.connection_proxy.block && self.respond_to?(:current_shard) && !self.current_shard.nil?
     end
 
     def reload_connection_safe(&block)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ Octopus.instance_variable_set(:@directory, File.dirname(__FILE__))
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
-  config.before(:each) do
+  config.before(:each) do |example|
     OctopusHelper.clean_all_shards(example.metadata[:shards])
   end
 end


### PR DESCRIPTION
Проблема такая:
при добавлении ассоциации, метод set_connection_on_association устанавливает для ее модели текущую шарду https://github.com/abak-press/octopus/blob/v0.7.x/lib/octopus/association.rb#L14

после чего эта шарда используется при каждом обращении к методам ассоциации
https://github.com/abak-press/octopus/blob/v0.7.x/lib/octopus/association_collection.rb#L23
https://github.com/abak-press/octopus/blob/v0.7.x/lib/octopus/model.rb#L107

даже если мы обращаемся к ней из Octopus.using

``` ruby
Octopus.using(:direct) do
  p ActiveRecord::Base.connection.current_shard
  company.products
  p ActiveRecord::Base.connection.current_shard
end
=> :direct
=> :master
```

`connection_proxy.block` в `lib/octopus/model.rb` является признаком выполнения кода в Octopus.using блоке
